### PR TITLE
Affi-Partnersのパラメーターを追加した

### DIFF
--- a/affiliate-parameter.js
+++ b/affiliate-parameter.js
@@ -29,6 +29,7 @@ var domainParamPairs = {
     //'gro-fru.net': 'uix',
     //'bizmotion.jp': 'uix',
     //'m-ads.jp': 'uix',
+    'aff.partners.io': 'afp',
   };
   
   var links = [].slice.call(document.getElementsByTagName('a'));


### PR DESCRIPTION
## 関連Issue
- https://github.com/indieverse-jp/ASP-ADMIN/issues/5027

## 実装内容
domainParamPairsに値を追加。
ドメイン'aff.partners.io'に対して、'afp'が付与されるようにした。

## 前提
AffiPartnersでは以下のような仕様になっている。
・管理画面では設定した任意の識別子を**afp**設定している → 「referrer」
・任意で設定した値（今回はreferrer）をもとに、どのアフィリエイトリンクからCVしたかの判断はできる
・設定した識別子は「登録数レポート」のafpカラムで確認できる
・具体的なリファラのURLは設定できていない

識別子(今回であればreferer)の設定方法は、
「マーケティングツール > すべてのマーケティングツール」のダイナミックパラメーター機能を用いて実現。
設定した値がURLパラメーター ("afp=")に自動入力される。

上記を踏まえて、リダイレクトページにURLパラメーターの実装で"afp="にリファラ値を付与。

## 挙動
例）
https://aff.partners.io/visit/?bta=4962&nci=6767&afp=[リファラ値]