### PR TITLE
Add affiliate parameter mapping for stair-s.com

### DIFF
--- a/affiliate-parameter.js
+++ b/affiliate-parameter.js
@@ -20,6 +20,7 @@ var domainParamPairs = {
     'rsmok.jp': 'pb',
     'matching-affi.jp': 'pb',
     'ratel-ad.com': 'pb',
+    'stair-s.com': 'pb',
     // famm
     'ver-net.jp': 'suid',
     'ad-track.jp': 'suid',


### PR DESCRIPTION
## Summary
- map stair-s.com to the pb query parameter so links receive the same affiliate tracking as other Affilicode domains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5d8ef7c348330b4edf468d82de477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded affiliate partner configuration. A new domain has been added to the affiliate parameter mapping system, enabling automatic tracking parameter insertion for links from this source. This expands partner coverage and ensures consistent tracking behavior and proper attribution management across all integrated affiliate sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->