### PR TITLE
Add affiliate domain parameter mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## 利用方法
 
 - bodyタグの最後に`<script src="https://cdn.jsdelivr.net/gh/indieverse-jp/affiliate-parameter@main/affiliate-parameter.js"></script>`を追加してください。
+- URLに`gcid`がある場合は、対象ASPリンクのパラメーターに`gcid,初回ランディングページURL`を追加します。
+- `gcid`と初回ランディングページURLはブラウザの`localStorage`に保存されるため、別ページへ移動した後の対象ASPリンクにも同じ値を追加します。
+- `gcid`が無い場合は、従来通り現在ページURLのみを対象ASPリンクのパラメーターに追加します。
 
 ```ruby
 <body>
@@ -10,4 +13,10 @@
     <a href="https://cl.link-ag.net/click/ab95a7/e7d510c5">Link AGのリンク</a>
     <script src="https://cdn.jsdelivr.net/gh/indieverse-jp/affiliate-parameter@main/affiliate-parameter.js"></script>
 </body>
+```
+
+## テスト
+
+```bash
+npm test
 ```

--- a/affiliate-parameter.js
+++ b/affiliate-parameter.js
@@ -22,17 +22,21 @@ var domainParamPairs = {
     'ratel-ad.com': 'pb',
     'aspservice.jp': 'pb',
     'stair-s.com': 'pb',
+    'sic-asp.com': 'pb',
     // famm
     'ver-net.jp': 'suid',
     'ad-track.jp': 'suid',
     'adplushome.com': 'suid',
     'fam-ad.com': 'suid',
+    'affiliateone.jp': 'suid',
     // affiliate_ad
     //'ra.excite.co.jp': 'uix',
     //'gro-fru.net': 'uix',
     //'bizmotion.jp': 'uix',
     //'m-ads.jp': 'uix',
     'aff.partners.io': 'afp',
+    'asset-insight.jp': 'afp',
+    'pointfun.jp': 'afp',
   };
   
   var links = [].slice.call(document.getElementsByTagName('a'));

--- a/affiliate-parameter.js
+++ b/affiliate-parameter.js
@@ -34,9 +34,9 @@ var domainParamPairs = {
     //'gro-fru.net': 'uix',
     //'bizmotion.jp': 'uix',
     //'m-ads.jp': 'uix',
-    'aff.partners.io': 'afp',
-    'asset-insight.jp': 'afp',
-    'pointfun.jp': 'afp',
+    'aff.partners.io': 'param2',
+    'asset-insight.jp': 'param2',
+    'pointfun.jp': 'param2',
   };
   
   var links = [].slice.call(document.getElementsByTagName('a'));

--- a/affiliate-parameter.js
+++ b/affiliate-parameter.js
@@ -38,7 +38,52 @@ var domainParamPairs = {
     'asset-insight.jp': 'param2',
     'pointfun.jp': 'param2',
   };
-  
+
+  var gcidStorageKey = 'affiliateParameter.gcid';
+  var landingPageUrlStorageKey = 'affiliateParameter.landingPageUrl';
+
+  function getQueryParam(name) {
+    var regexp = new RegExp('[?&]' + name + '=([^&#]*)');
+    var result = regexp.exec(window.location.search);
+    if (!result) {
+      return '';
+    }
+
+    try {
+      return decodeURIComponent(result[1].replace(/\+/g, ' '));
+    } catch (e) {
+      return result[1];
+    }
+  }
+
+  function getStorageValue(key) {
+    try {
+      return window.localStorage.getItem(key) || '';
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function setStorageValue(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (e) {
+    }
+  }
+
+  var gcid = getQueryParam('gcid');
+  var landingPageUrl = document.URL;
+
+  if (gcid) {
+    setStorageValue(gcidStorageKey, gcid);
+    setStorageValue(landingPageUrlStorageKey, landingPageUrl);
+  } else {
+    gcid = getStorageValue(gcidStorageKey);
+    landingPageUrl = getStorageValue(landingPageUrlStorageKey) || document.URL;
+  }
+
+  var affiliateParamValue = gcid ? gcid + ',' + landingPageUrl : document.URL;
+
   var links = [].slice.call(document.getElementsByTagName('a'));
   links.some(function(e) {
     var url = e.href;
@@ -47,9 +92,9 @@ var domainParamPairs = {
       if (url.indexOf(domain) !== -1) {
         var paramKey = domainParamPairs[domain];
         if (url.indexOf('?') === -1) {
-          url += '?' + paramKey + '=' + document.URL;
+          url += '?' + paramKey + '=' + encodeURIComponent(affiliateParamValue);
         } else {
-          url += '&' + paramKey + '=' + document.URL;
+          url += '&' + paramKey + '=' + encodeURIComponent(affiliateParamValue);
         }
         e.setAttribute('href', url);
         return;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "test": "node test/affiliate-parameter.test.js"
+  }
+}

--- a/sample.html
+++ b/sample.html
@@ -2,9 +2,10 @@
 <head>    
 </head>
 <body>
+    <p>gcid付きで開く例: sample.html?gcid=test123</p>
     <a href="https://ad.presco.asia/cl/?b_id=tZLrIM4P&t_id=1">Prescoのリンク</a>
     <a href="https://cl.link-ag.net/click/ab95a7/e7d510c5">Link AGのリンク</a>
     <!-- bodyタグの最後にaffiliate-parameter.jsを埋め込んでください-->
-    <script src="https://cdn.jsdelivr.net/gh/indieverse-jp/affiliate-parameter@main/affiliate-parameter.js"></script>
+    <script src="./affiliate-parameter.js"></script>
 </body>
 </html>

--- a/test/affiliate-parameter.test.js
+++ b/test/affiliate-parameter.test.js
@@ -1,0 +1,201 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const script = fs.readFileSync(
+  path.join(__dirname, '..', 'affiliate-parameter.js'),
+  'utf8'
+);
+
+function createStorage(initialData) {
+  const data = Object.assign({}, initialData);
+
+  return {
+    data,
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null;
+    },
+    setItem(key, value) {
+      data[key] = String(value);
+    }
+  };
+}
+
+function createUnavailableStorage() {
+  return {
+    getItem() {
+      throw new Error('localStorage is unavailable');
+    },
+    setItem() {
+      throw new Error('localStorage is unavailable');
+    }
+  };
+}
+
+function rewriteLinks(pageUrl, linkHrefs, storage) {
+  const anchors = linkHrefs.map(function(href) {
+    return {
+      href: href,
+      setAttribute(name, value) {
+        if (name === 'href') {
+          this.href = value;
+        }
+      }
+    };
+  });
+  const parsedPageUrl = new URL(pageUrl);
+
+  vm.runInNewContext(script, {
+    window: {
+      location: {
+        search: parsedPageUrl.search
+      },
+      localStorage: storage
+    },
+    document: {
+      URL: pageUrl,
+      getElementsByTagName(tagName) {
+        return tagName === 'a' ? anchors : [];
+      }
+    },
+    RegExp,
+    decodeURIComponent,
+    encodeURIComponent
+  });
+
+  return anchors.map(function(anchor) {
+    return anchor.href;
+  });
+}
+
+function getParam(url, key) {
+  return new URL(url).searchParams.get(key);
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('ok - ' + name);
+  } catch (error) {
+    console.error('not ok - ' + name);
+    throw error;
+  }
+}
+
+test('uses gcid and the first landing page URL when gcid exists', function() {
+  const storage = createStorage();
+  const pageUrl = 'https://example.com/lp?gcid=test123&utm_source=ad';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://ad.presco.asia/cl/?b_id=tZLrIM4P&t_id=1'],
+    storage
+  );
+
+  assert.strictEqual(
+    getParam(rewritten[0], 'afad_param_1'),
+    'test123,' + pageUrl
+  );
+  assert.strictEqual(storage.data['affiliateParameter.gcid'], 'test123');
+  assert.strictEqual(storage.data['affiliateParameter.landingPageUrl'], pageUrl);
+});
+
+test('reuses stored gcid and landing page URL after navigating to another page', function() {
+  const landingPageUrl = 'https://example.com/lp?gcid=test123&utm_source=ad';
+  const storage = createStorage({
+    'affiliateParameter.gcid': 'test123',
+    'affiliateParameter.landingPageUrl': landingPageUrl
+  });
+  const rewritten = rewriteLinks(
+    'https://example.com/next-page',
+    ['https://cl.link-ag.net/click/ab95a7/e7d510c5'],
+    storage
+  );
+
+  assert.strictEqual(
+    getParam(rewritten[0], 'sid'),
+    'test123,' + landingPageUrl
+  );
+});
+
+test('falls back to the current page URL when gcid has never been stored', function() {
+  const storage = createStorage();
+  const pageUrl = 'https://example.com/no-gcid?x=1';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://ad.presco.asia/cl/?b_id=tZLrIM4P&t_id=1'],
+    storage
+  );
+
+  assert.strictEqual(getParam(rewritten[0], 'afad_param_1'), pageUrl);
+});
+
+test('overwrites the stored gcid and landing page URL on a new gcid visit', function() {
+  const storage = createStorage({
+    'affiliateParameter.gcid': 'old123',
+    'affiliateParameter.landingPageUrl': 'https://example.com/old-lp?gcid=old123'
+  });
+  const pageUrl = 'https://example.com/new-lp?gcid=next456';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://ad.presco.asia/cl/?b_id=tZLrIM4P&t_id=1'],
+    storage
+  );
+
+  assert.strictEqual(
+    getParam(rewritten[0], 'afad_param_1'),
+    'next456,' + pageUrl
+  );
+  assert.strictEqual(storage.data['affiliateParameter.gcid'], 'next456');
+  assert.strictEqual(storage.data['affiliateParameter.landingPageUrl'], pageUrl);
+});
+
+test('works without localStorage when gcid is on the current URL', function() {
+  const pageUrl = 'https://example.com/storage-disabled?gcid=inline789';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://ad.presco.asia/cl/'],
+    createUnavailableStorage()
+  );
+
+  assert.strictEqual(
+    getParam(rewritten[0], 'afad_param_1'),
+    'inline789,' + pageUrl
+  );
+});
+
+test('uses ampersand for affiliate links that already have query parameters', function() {
+  const storage = createStorage();
+  const pageUrl = 'https://example.com/lp?gcid=test123';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://ad.presco.asia/cl/?b_id=tZLrIM4P&t_id=1'],
+    storage
+  );
+
+  assert.match(rewritten[0], /&afad_param_1=/);
+});
+
+test('uses question mark for affiliate links without query parameters', function() {
+  const storage = createStorage();
+  const pageUrl = 'https://example.com/lp?gcid=test123';
+  const rewritten = rewriteLinks(
+    pageUrl,
+    ['https://cl.link-ag.net/click/ab95a7/e7d510c5'],
+    storage
+  );
+
+  assert.match(rewritten[0], /\\?sid=/);
+});
+
+test('does not modify links for unsupported domains', function() {
+  const storage = createStorage();
+  const link = 'https://example.net/normal-link';
+  const rewritten = rewriteLinks(
+    'https://example.com/lp?gcid=test123',
+    [link],
+    storage
+  );
+
+  assert.strictEqual(rewritten[0], link);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved affiliate link tracking by persisting `gcid` and the initial landing page, then reusing them on subsequent navigation.
  * Link rewriting now appends tracking data based on the current or initial landing context and URL-encodes the value.
* **Chores**
  * Expanded partner domain coverage and updated several affiliate parameter key mappings.
* **Documentation**
  * Updated README usage and added a `gcid` example; sample page script path adjusted to use a local reference.
* **Tests**
  * Added a comprehensive test suite covering encoding, storage fallback, delimiter behavior, and unsupported domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->